### PR TITLE
Fix number order abbreviations and shorten formatter

### DIFF
--- a/pepy/application/query.py
+++ b/pepy/application/query.py
@@ -9,13 +9,13 @@ from pepy.domain.repository import ProjectRepository
 
 
 class DownloadsNumberFormatter:
-    _MILLNAMES = ['', 'K', 'M', 'B', 'T', 'Q']
+    _METRIC_PREFIX = ['', 'k', 'M', 'G', 'T', 'P']
 
     def format(self, downloads: Downloads) -> str:
         digits = int(math.log10(abs(downloads.value)) if downloads.value else 0)
-        millidx = max(0, min(len(self._MILLNAMES) - 1, digits // 3))
+        millidx = max(0, min(len(self._METRIC_PREFIX) - 1, digits // 3))
         rounded_value = downloads.value // (10 ** (3 * millidx))
-        return '{}{}'.format(rounded_value, self._MILLNAMES[millidx])
+        return '{}{}'.format(rounded_value, self._METRIC_PREFIX[millidx])
 
 
 class BadgeProvider:

--- a/pepy/application/query.py
+++ b/pepy/application/query.py
@@ -9,15 +9,13 @@ from pepy.domain.repository import ProjectRepository
 
 
 class DownloadsNumberFormatter:
-    _MILLNAMES = ['', 'k', 'M', 'G', 'T']
+    _MILLNAMES = ['', 'K', 'M', 'B', 'T', 'Q']
 
     def format(self, downloads: Downloads) -> str:
-        digits = int(math.floor(0 if downloads.value == 0 else math.log10(abs(downloads.value)) / 3))
-        millidx = max(0, min(len(self._MILLNAMES) - 1, digits))
-        value = math.floor(downloads.value / 10 ** (3 * millidx))
-        if millidx == 0:
-            return '{}{}'.format(value, self._MILLNAMES[millidx])
-        return '{}{}'.format(value, self._MILLNAMES[millidx])
+        digits = int(math.log10(abs(downloads.value)) if downloads.value else 0)
+        millidx = max(0, min(len(self._MILLNAMES) - 1, digits // 3))
+        rounded_value = downloads.value // (10 ** (3 * millidx))
+        return '{}{}'.format(rounded_value, self._MILLNAMES[millidx])
 
 
 class BadgeProvider:

--- a/pepy/application/query.py
+++ b/pepy/application/query.py
@@ -21,7 +21,6 @@ class DownloadsNumberFormatter:
 
 
 class BadgeProvider:
-    _MILLNAMES = ['', 'k', 'M', 'G', 'T']
 
     def __init__(self, project_repository: ProjectRepository, downloads_formatter: DownloadsNumberFormatter):
         self._project_repository = project_repository

--- a/tests/unit/application/test_query.py
+++ b/tests/unit/application/test_query.py
@@ -16,7 +16,7 @@ def test_downloads_format_less_than_thousands(downloads_formatter: DownloadsNumb
 
 def test_downloads_format_thousands(downloads_formatter: DownloadsNumberFormatter):
     downloads = Downloads(12_132)
-    assert '12k' == downloads_formatter.format(downloads)
+    assert '12K' == downloads_formatter.format(downloads)
 
 
 def test_downloads_format_million(downloads_formatter: DownloadsNumberFormatter):
@@ -26,9 +26,14 @@ def test_downloads_format_million(downloads_formatter: DownloadsNumberFormatter)
 
 def test_downloads_format_billion(downloads_formatter: DownloadsNumberFormatter):
     downloads = Downloads(9_132_919_492)
-    assert '9G' == downloads_formatter.format(downloads)
+    assert '9B' == downloads_formatter.format(downloads)
 
 
 def test_downloads_format_trillion(downloads_formatter: DownloadsNumberFormatter):
     downloads = Downloads(11_132_919_492_000)
     assert '11T' == downloads_formatter.format(downloads)
+
+
+def test_downloads_format_quadrillion(downloads_formatter: DownloadsNumberFormatter):
+    downloads = Downloads(11_132_919_492_432_000)
+    assert '11Q' == downloads_formatter.format(downloads)

--- a/tests/unit/application/test_query.py
+++ b/tests/unit/application/test_query.py
@@ -16,7 +16,7 @@ def test_downloads_format_less_than_thousands(downloads_formatter: DownloadsNumb
 
 def test_downloads_format_thousands(downloads_formatter: DownloadsNumberFormatter):
     downloads = Downloads(12_132)
-    assert '12K' == downloads_formatter.format(downloads)
+    assert '12k' == downloads_formatter.format(downloads)
 
 
 def test_downloads_format_million(downloads_formatter: DownloadsNumberFormatter):
@@ -26,7 +26,7 @@ def test_downloads_format_million(downloads_formatter: DownloadsNumberFormatter)
 
 def test_downloads_format_billion(downloads_formatter: DownloadsNumberFormatter):
     downloads = Downloads(9_132_919_492)
-    assert '9B' == downloads_formatter.format(downloads)
+    assert '9G' == downloads_formatter.format(downloads)
 
 
 def test_downloads_format_trillion(downloads_formatter: DownloadsNumberFormatter):
@@ -36,4 +36,4 @@ def test_downloads_format_trillion(downloads_formatter: DownloadsNumberFormatter
 
 def test_downloads_format_quadrillion(downloads_formatter: DownloadsNumberFormatter):
     downloads = Downloads(11_132_919_492_432_000)
-    assert '11Q' == downloads_formatter.format(downloads)
+    assert '11P' == downloads_formatter.format(downloads)


### PR DESCRIPTION
I think B works better for Billions than G. Also I uppercased K for consistency. I added Q for quadrillions just for kicks.
In `.format()` I removed `math.floor` because it's what `int` implicitly does. Also, I replaced float division with integer division.