### PR TITLE
Comma separate thousands

### DIFF
--- a/pepy/infrastructure/web/templates/project.html
+++ b/pepy/infrastructure/web/templates/project.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}{{ project.name.name }} download stats{% endblock %}
-{% block meta %}{{ project.name.name }} was downloaded {{ project.downloads.value }} times. Get more downloads stats about any Python package.{% endblock %}
+{% block meta %}{{ project.name.name }} was downloaded {{ '{:,}'.format(project.downloads.value) }} times. Get more downloads stats about any Python package.{% endblock %}
 
 {% block content %}
     <nav aria-label="breadcrumb">
@@ -20,7 +20,7 @@
             <tbody>
             <tr>
                 <th>Total downloads</th>
-                <td>{{ project.downloads.value }}</td>
+                <td>{{ '{:,}'.format(project.downloads.value) }}</td>
             </tr>
             <tr>
                 <th>pypi link</th>
@@ -61,7 +61,7 @@
             {% for download in downloads %}
                 <tr>
                     <td>{{ download.day.strftime('%Y-%m-%d') }}</td>
-                    <td>{{ download.downloads.value }}</td>
+                    <td>{{ '{:,}'.format(download.downloads.value) }}</td>
                 </tr>
             {% endfor %}
             </tbody>


### PR DESCRIPTION
Note: I've not tested this.

It's very hard to read long, big numbers:

![image](https://user-images.githubusercontent.com/1324225/45844260-90c66f80-bd2a-11e8-8d94-236fdc8ed0bb.png)

It would help a lot to separate them with commas.

Alternatively, if commas look a bit odd for those from countries where commas are used for the decimal point, then space separating is also common and would help readability a lot.
 
http://wordpress.mrreid.org/2014/05/27/stop-putting-commas-in-your-numbers/
