### PR TITLE
Switch suffix for 10^9 downloads from 'G' to 'B'

### DIFF
--- a/pepy/application/query.py
+++ b/pepy/application/query.py
@@ -10,7 +10,7 @@ from pepy.domain.view import ProjectView
 
 
 class DownloadsNumberFormatter:
-    _METRIC_PREFIX = ["", "k", "M", "G", "T", "P"]
+    _METRIC_PREFIX = ["", "k", "M", "B", "T", "Q"]
 
     def format(self, downloads: int) -> str:
         digits = int(math.log10(abs(downloads)) if downloads else 0)

--- a/tests/unit/application/test_query.py
+++ b/tests/unit/application/test_query.py
@@ -26,7 +26,7 @@ def test_downloads_format_million(downloads_formatter: DownloadsNumberFormatter)
 
 def test_downloads_format_billion(downloads_formatter: DownloadsNumberFormatter):
     downloads = 9_132_919_492
-    assert "9G" == downloads_formatter.format(downloads)
+    assert "9B" == downloads_formatter.format(downloads)
 
 
 def test_downloads_format_trillion(downloads_formatter: DownloadsNumberFormatter):
@@ -36,4 +36,4 @@ def test_downloads_format_trillion(downloads_formatter: DownloadsNumberFormatter
 
 def test_downloads_format_quadrillion(downloads_formatter: DownloadsNumberFormatter):
     downloads = 11_132_919_492_432_000
-    assert "11P" == downloads_formatter.format(downloads)
+    assert "11Q" == downloads_formatter.format(downloads)


### PR DESCRIPTION
On [behalf](https://pepy.tech/project/urllib3) [of](https://pepy.tech/project/six) [the](https://pepy.tech/project/python-dateutil) [billionaires](https://pepy.tech/project/botocore) [club](https://pepy.tech/project/pip) :moneybag: I think the download badges should read "Billion" rather than "Giga". The unit test names suggest this was considered.

Also switched from peta to quadrillion, probably won't have to worry about that though! :)