### PR TITLE
swapping json.dumps() with flask jsonify()

### DIFF
--- a/pepy/infrastructure/api/__init__.py
+++ b/pepy/infrastructure/api/__init__.py
@@ -1,6 +1,6 @@
 import json
 
-from flask import Blueprint
+from flask import Blueprint, jsonify
 from pepy.infrastructure import container
 from pepy.infrastructure.api._transformer import transform_project, transform_project_item
 
@@ -10,10 +10,10 @@ api = Blueprint("api", __name__)
 @api.route("/projects/<project_name>", methods=["GET"])
 def project_action(project_name):
     project = container.project_provider.find(project_name)
-    return json.dumps(transform_project(project))
+    return jsonify(transform_project(project))
 
 
 @api.route("/projects", methods=["GET"])
 def project_find():
     projects = container.project_provider.for_home()
-    return json.dumps([transform_project_item(p) for p in projects])
+    return jsonify([transform_project_item(p) for p in projects])

--- a/pepy/infrastructure/web/__init__.py
+++ b/pepy/infrastructure/web/__init__.py
@@ -1,7 +1,7 @@
 import json
 import traceback
 
-from flask import Flask, Response, request
+from flask import Flask, Response, request, jsonify
 
 from pepy.domain.exception import DomainException, ProjectNotFoundException
 from pepy.infrastructure import container
@@ -14,7 +14,7 @@ app.register_blueprint(api, url_prefix="/api")
 
 @app.route("/health-check")
 def health_check_action():
-    return json.dumps({"status": "healthy"})
+    return jsonify({"status": "healthy"})
 
 
 @app.route("/badge/<project_name>")


### PR DESCRIPTION
Hey Petru,

We have a free program analysis tool for Python based web projects, called Bento. While we were scanning GitHub projects for issues, your project triggered a warning for using json.dumps() instead of flask jsonify().

Jsonify automatically creates a Flask `Response` object with the proper mime-types among other things, so it is considered a better practice. There is a decent discussion about it on Stackoverflow (https://stackoverflow.com/questions/7907596/json-dumps-vs-flask-jsonify). 

Otherwise, your code looks really clean. Feel free download Bento (https://bento.dev) and take a look at it yourself.