### PR TITLE
feat: add `mightbesimon.com` to CORS origins list

### DIFF
--- a/pepy/infrastructure/web/__init__.py
+++ b/pepy/infrastructure/web/__init__.py
@@ -12,7 +12,11 @@ from pepy.infrastructure.api import api
 app = Flask(__name__)
 app.config.from_object(container.config)
 app.register_blueprint(api, url_prefix="/api")
-CORS(app, resources={r"/api/*": {"origins": ["https://pepy.tech", "http://localhost:3000"]}})
+CORS(app, resources={r"/api/*": {"origins": [
+    "https://pepy.tech",
+    "https://mightbesimon.com",
+    "http://localhost:3000",
+]}})
 
 
 @app.route("/health-check")


### PR DESCRIPTION
Allows my website mightbesimon.com to use api.pepy.tech
Thank you Petru for making this API and allowing me to contribute 😊